### PR TITLE
맛집 추천 API 구현, Restaurant 도메인 수정

### DIFF
--- a/TodaysLunch/src/main/java/LikeLion/TodaysLunch/config/TodaysLunchConfig.java
+++ b/TodaysLunch/src/main/java/LikeLion/TodaysLunch/config/TodaysLunchConfig.java
@@ -44,7 +44,7 @@ public class TodaysLunchConfig {
     public RestaurantService restaurantService() {
         return new RestaurantService(restaurantRepository,
                 foodCategoryRepository, locationTagRepository,
-                locationCategoryRepository, imageUrlRepository);
+                locationCategoryRepository, imageUrlRepository, memberRepository);
     }
 
 

--- a/TodaysLunch/src/main/java/LikeLion/TodaysLunch/config/WebSecurityConfig.java
+++ b/TodaysLunch/src/main/java/LikeLion/TodaysLunch/config/WebSecurityConfig.java
@@ -43,9 +43,8 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
                 .and()
 
                 .authorizeRequests()
-                .antMatchers("/restaurants/test").authenticated()
                 .antMatchers("/**", "/join", "/login", "/h2-console/**").permitAll()
-//                .anyRequest().authenticated()
+                .anyRequest().authenticated()
                 .and()
 
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);

--- a/TodaysLunch/src/main/java/LikeLion/TodaysLunch/config/WebSecurityConfig.java
+++ b/TodaysLunch/src/main/java/LikeLion/TodaysLunch/config/WebSecurityConfig.java
@@ -43,8 +43,9 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
                 .and()
 
                 .authorizeRequests()
+                .antMatchers("/restaurants/test").authenticated()
                 .antMatchers("/**", "/join", "/login", "/h2-console/**").permitAll()
-                .anyRequest().authenticated()
+//                .anyRequest().authenticated()
                 .and()
 
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);

--- a/TodaysLunch/src/main/java/LikeLion/TodaysLunch/controller/MenuController.java
+++ b/TodaysLunch/src/main/java/LikeLion/TodaysLunch/controller/MenuController.java
@@ -5,8 +5,10 @@ import LikeLion.TodaysLunch.domain.Restaurant;
 import LikeLion.TodaysLunch.service.MenuService;
 import LikeLion.TodaysLunch.service.RestaurantService;
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -33,10 +35,13 @@ public class MenuController {
   }
 
   @GetMapping("restaurants/{restaurantId}/menus")
-  public ResponseEntity<List<Menu>> menuList(@PathVariable Long restaurantId) {
+  public ResponseEntity<HashMap<String, Object>> menuList(@PathVariable Long restaurantId, Pageable pageable) {
     Restaurant restaurant = restaurantService.restaurantDetail(restaurantId);
-    List<Menu> menus = menuService.findMenuByRestaurant(restaurant);
-    return ResponseEntity.status(HttpStatus.OK).body(menus);
+    Page<Menu> menus = menuService.findMenuByRestaurant(restaurant, pageable);
+    HashMap<String, Object> responseMap = new HashMap<>();
+    responseMap.put("data", menus.getContent());
+    responseMap.put("totalPages", menus.getTotalPages());
+    return ResponseEntity.status(HttpStatus.OK).body(responseMap);
   }
 
   @PostMapping("restaurants/{restaurantId}/menus")

--- a/TodaysLunch/src/main/java/LikeLion/TodaysLunch/controller/MenuController.java
+++ b/TodaysLunch/src/main/java/LikeLion/TodaysLunch/controller/MenuController.java
@@ -52,10 +52,9 @@ public class MenuController {
   }
 
   @PatchMapping("restaurants/{restaurantId}/menus/{menuId}")
-  public ResponseEntity<Menu> updateMenu(@RequestParam(required = false) MultipartFile menuImage,
-      @RequestParam(required = false) String name, @RequestParam(required = false) Long price,
-      @PathVariable Long restaurantId, @PathVariable Long menuId) throws IOException {
-    Menu menu = menuService.update(menuImage, name, price, restaurantId, menuId);
+  public ResponseEntity<Menu> updateMenu(@RequestParam(required = false) String name, @RequestParam(required = false) Long price,
+      @PathVariable Long restaurantId, @PathVariable Long menuId) {
+    Menu menu = menuService.update(name, price, restaurantId, menuId);
     return ResponseEntity.status(HttpStatus.OK).body(menu);
   }
 

--- a/TodaysLunch/src/main/java/LikeLion/TodaysLunch/controller/RestaurantController.java
+++ b/TodaysLunch/src/main/java/LikeLion/TodaysLunch/controller/RestaurantController.java
@@ -68,10 +68,9 @@ public class RestaurantController {
   public ResponseEntity<Restaurant> createJudge(
       @RequestParam(required = false) MultipartFile restaurantImage, @RequestParam(required = false) String address, @RequestParam String restaurantName,
       @RequestParam String foodCategoryName, @RequestParam String locationCategoryName,
-      @RequestParam String locationTagName, @RequestParam(required = false) String introduction,
-      @AuthenticationPrincipal Member member
+      @RequestParam String locationTagName, @RequestParam(required = false) String introduction
   ) throws IOException {
-    Restaurant restaurant = restaurantService.createJudgeRestaurant(member, address, restaurantName,
+    Restaurant restaurant = restaurantService.createJudgeRestaurant(address, restaurantName,
         foodCategoryName, locationCategoryName, locationTagName, introduction, restaurantImage);
     return ResponseEntity.status(HttpStatus.OK).body(restaurant);
   }

--- a/TodaysLunch/src/main/java/LikeLion/TodaysLunch/controller/RestaurantController.java
+++ b/TodaysLunch/src/main/java/LikeLion/TodaysLunch/controller/RestaurantController.java
@@ -1,19 +1,13 @@
 package LikeLion.TodaysLunch.controller;
 
-import LikeLion.TodaysLunch.domain.FoodCategory;
-import LikeLion.TodaysLunch.domain.Menu;
+
 import LikeLion.TodaysLunch.domain.Restaurant;
-import LikeLion.TodaysLunch.dto.JudgeDto;
-import LikeLion.TodaysLunch.repository.RestaurantSpecification;
-import LikeLion.TodaysLunch.service.MenuService;
 import LikeLion.TodaysLunch.service.RestaurantService;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-import javax.servlet.http.HttpServletRequest;
+import java.util.HashMap;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.jpa.domain.Specification;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -44,7 +38,7 @@ public class RestaurantController {
    * restaurant?food-category=korean&location-category=sogang&location-tag&keyword=검색어&page=1&size=5&sorting=rating&order=ascending
    */
   @GetMapping("")
-  public ResponseEntity<List<Restaurant>> allRestaurantList(
+  public ResponseEntity<HashMap<String, Object>> allRestaurantList(
       @RequestParam(value = "food-category", required = false) String foodCategory,
       @RequestParam(value = "location-category", required = false) String locationCategory,
       @RequestParam(value = "location-tag", required = false) String locationTag,
@@ -53,9 +47,12 @@ public class RestaurantController {
       @RequestParam(defaultValue = PAGE_SIZE) int size,
       @RequestParam(defaultValue = SORT) String sort,
       @RequestParam(defaultValue = ORDER) String order) {
-    List<Restaurant> restaurants = restaurantService.restaurantList(foodCategory, locationCategory,
-        locationTag, keyword, page, size, sort, order).getContent();
-    return ResponseEntity.status(HttpStatus.OK).body(restaurants);
+    Page<Restaurant> restaurants = restaurantService.restaurantList(foodCategory, locationCategory,
+        locationTag, keyword, page, size, sort, order);
+    HashMap<String, Object> responseMap = new HashMap<>();
+    responseMap.put("data", restaurants.getContent());
+    responseMap.put("totalPages", restaurants.getTotalPages());
+    return ResponseEntity.status(HttpStatus.OK).body(responseMap);
   }
 
   @GetMapping("/{restaurantId}")
@@ -77,8 +74,11 @@ public class RestaurantController {
   }
 
   @GetMapping("/judges")
-  public ResponseEntity<List<Restaurant>> AllJudgeRestaurantList(Pageable pageable){
-  List<Restaurant> restaurants = restaurantService.judgeRestaurantList(pageable).getContent();
-  return ResponseEntity.status(HttpStatus.OK).body(restaurants);
+  public ResponseEntity<HashMap<String, Object>> AllJudgeRestaurantList(Pageable pageable){
+  Page<Restaurant> restaurants = restaurantService.judgeRestaurantList(pageable);
+  HashMap<String, Object> responseMap = new HashMap<>();
+  responseMap.put("data", restaurants.getContent());
+  responseMap.put("totalPages", restaurants.getTotalPages());
+  return ResponseEntity.status(HttpStatus.OK).body(responseMap);
   }
 }

--- a/TodaysLunch/src/main/java/LikeLion/TodaysLunch/controller/RestaurantController.java
+++ b/TodaysLunch/src/main/java/LikeLion/TodaysLunch/controller/RestaurantController.java
@@ -6,6 +6,7 @@ import LikeLion.TodaysLunch.domain.Restaurant;
 import LikeLion.TodaysLunch.service.RestaurantService;
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -31,14 +32,6 @@ public class RestaurantController {
     this.restaurantService = restaurantService;
   }
 
-  /**
-   * paging parameter 예시
-   * http://localhost:8080/restaurant?page=1&size=5
-   */
-  /**
-   * 설계
-   * restaurant?food-category=korean&location-category=sogang&location-tag&keyword=검색어&page=1&size=5&sorting=rating&order=ascending
-   */
   @GetMapping("")
   public ResponseEntity<HashMap<String, Object>> allRestaurantList(
       @RequestParam(value = "food-category", required = false) String foodCategory,
@@ -63,7 +56,6 @@ public class RestaurantController {
     return ResponseEntity.status(HttpStatus.OK).body(restaurant);
   }
 
-
   @PostMapping("/judges")
   public ResponseEntity<Restaurant> createJudge(
       @RequestParam(required = false) MultipartFile restaurantImage, @RequestParam(required = false) String address, @RequestParam String restaurantName,
@@ -87,5 +79,12 @@ public class RestaurantController {
   responseMap.put("data", restaurants.getContent());
   responseMap.put("totalPages", restaurants.getTotalPages());
   return ResponseEntity.status(HttpStatus.OK).body(responseMap);
+  }
+
+  // 임시로 유저의 ID 값을 경로 변수로 받기
+  @GetMapping("/recommendation/{userId}")
+  public ResponseEntity<List<Restaurant>> recommendation(@PathVariable Long userId){
+    List<Restaurant> restaurants = restaurantService.recommendation(userId);
+    return ResponseEntity.status(HttpStatus.OK).body(restaurants);
   }
 }

--- a/TodaysLunch/src/main/java/LikeLion/TodaysLunch/controller/RestaurantController.java
+++ b/TodaysLunch/src/main/java/LikeLion/TodaysLunch/controller/RestaurantController.java
@@ -1,6 +1,7 @@
 package LikeLion.TodaysLunch.controller;
 
 
+import LikeLion.TodaysLunch.domain.Member;
 import LikeLion.TodaysLunch.domain.Restaurant;
 import LikeLion.TodaysLunch.service.RestaurantService;
 import java.io.IOException;
@@ -10,6 +11,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -66,11 +68,17 @@ public class RestaurantController {
   public ResponseEntity<Restaurant> createJudge(
       @RequestParam(required = false) MultipartFile restaurantImage, @RequestParam(required = false) String address, @RequestParam String restaurantName,
       @RequestParam String foodCategoryName, @RequestParam String locationCategoryName,
-      @RequestParam String locationTagName, @RequestParam(required = false) String introduction
+      @RequestParam String locationTagName, @RequestParam(required = false) String introduction,
+      @AuthenticationPrincipal Member member
   ) throws IOException {
-    Restaurant restaurant = restaurantService.createJudgeRestaurant(address, restaurantName,
+    Restaurant restaurant = restaurantService.createJudgeRestaurant(member, address, restaurantName,
         foodCategoryName, locationCategoryName, locationTagName, introduction, restaurantImage);
     return ResponseEntity.status(HttpStatus.OK).body(restaurant);
+  }
+
+  @GetMapping("/test")
+  public String test(){
+    return "success";
   }
 
   @GetMapping("/judges")

--- a/TodaysLunch/src/main/java/LikeLion/TodaysLunch/controller/ReviewController.java
+++ b/TodaysLunch/src/main/java/LikeLion/TodaysLunch/controller/ReviewController.java
@@ -3,8 +3,10 @@ package LikeLion.TodaysLunch.controller;
 import LikeLion.TodaysLunch.domain.Review;
 import LikeLion.TodaysLunch.dto.ReviewDto;
 import LikeLion.TodaysLunch.service.ReviewService;
+import java.util.HashMap;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -33,9 +35,12 @@ public class ReviewController {
   }
 
   @GetMapping("/restaurants/{restaurantId}/reviews")
-  public ResponseEntity<List<Review>> allReviewList(@PathVariable Long restaurantId, Pageable pageable){
-    List<Review> reviews = reviewService.reviewsList(restaurantId, pageable).getContent();
-    return ResponseEntity.status(HttpStatus.OK).body(reviews);
+  public ResponseEntity<HashMap<String, Object>> allReviewList(@PathVariable Long restaurantId, Pageable pageable){
+    Page<Review> reviews = reviewService.reviewsList(restaurantId, pageable);
+    HashMap<String, Object> responseMap = new HashMap<>();
+    responseMap.put("data", reviews.getContent());
+    responseMap.put("totalPages", reviews.getTotalPages());
+    return ResponseEntity.status(HttpStatus.OK).body(responseMap);
   }
 
   @PatchMapping("/restaurants/{restaurantId}/reviews/{reviewId}")

--- a/TodaysLunch/src/main/java/LikeLion/TodaysLunch/controller/SaleController.java
+++ b/TodaysLunch/src/main/java/LikeLion/TodaysLunch/controller/SaleController.java
@@ -5,8 +5,10 @@ import LikeLion.TodaysLunch.domain.Sale;
 import LikeLion.TodaysLunch.dto.SaleDto;
 import LikeLion.TodaysLunch.service.MenuService;
 import LikeLion.TodaysLunch.service.SaleService;
+import java.util.HashMap;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -25,9 +27,12 @@ public class SaleController {
   }
 
   @GetMapping("/sale-menus")
-  public ResponseEntity<List<Menu>> saleMenuList(Pageable pageable){
-    List<Menu> menus = saleService.saleMenuList(pageable).getContent();
-    return ResponseEntity.status(HttpStatus.OK).body(menus);
+  public ResponseEntity<HashMap<String, Object>> saleMenuList(Pageable pageable){
+    Page<Menu> menus = saleService.saleMenuList(pageable);
+    HashMap<String, Object> responseMap = new HashMap<>();
+    responseMap.put("data", menus.getContent());
+    responseMap.put("totalPages", menus.getTotalPages());
+    return ResponseEntity.status(HttpStatus.OK).body(responseMap);
   }
 
   @PostMapping("/menus/{menuId}/sale")

--- a/TodaysLunch/src/main/java/LikeLion/TodaysLunch/domain/FoodCategory.java
+++ b/TodaysLunch/src/main/java/LikeLion/TodaysLunch/domain/FoodCategory.java
@@ -12,7 +12,7 @@ public class FoodCategory {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
-  @NotNull
+  @Column(nullable = false)
   private String name;
 
 }

--- a/TodaysLunch/src/main/java/LikeLion/TodaysLunch/domain/ImageUrl.java
+++ b/TodaysLunch/src/main/java/LikeLion/TodaysLunch/domain/ImageUrl.java
@@ -5,6 +5,9 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToOne;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -19,4 +22,8 @@ public class ImageUrl {
   private String originalName;
   @Column(nullable = false)
   private String imageUrl;
+
+  @ManyToOne
+  @JoinColumn
+  private Menu menu;
 }

--- a/TodaysLunch/src/main/java/LikeLion/TodaysLunch/domain/ImageUrl.java
+++ b/TodaysLunch/src/main/java/LikeLion/TodaysLunch/domain/ImageUrl.java
@@ -1,5 +1,6 @@
 package LikeLion.TodaysLunch.domain;
 
+import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
@@ -14,6 +15,8 @@ public class ImageUrl {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
+  @Column(nullable = false)
   private String originalName;
+  @Column(nullable = false)
   private String imageUrl;
 }

--- a/TodaysLunch/src/main/java/LikeLion/TodaysLunch/domain/LocationCategory.java
+++ b/TodaysLunch/src/main/java/LikeLion/TodaysLunch/domain/LocationCategory.java
@@ -11,6 +11,11 @@ public class LocationCategory {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
+  @Column(nullable = false)
   private String name;
+  @Column(nullable = false)
+  private Double latitude;
+  @Column(nullable = false)
+  private Double longitude;
 
 }

--- a/TodaysLunch/src/main/java/LikeLion/TodaysLunch/domain/LocationTag.java
+++ b/TodaysLunch/src/main/java/LikeLion/TodaysLunch/domain/LocationTag.java
@@ -11,5 +11,6 @@ public class LocationTag {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
+  @Column(nullable = false)
   private String name;
 }

--- a/TodaysLunch/src/main/java/LikeLion/TodaysLunch/domain/Member.java
+++ b/TodaysLunch/src/main/java/LikeLion/TodaysLunch/domain/Member.java
@@ -42,11 +42,9 @@ public class Member implements UserDetails {
 
     @ManyToOne
     @JoinColumn
-    @Column(nullable = false)
     private LocationCategory locationCategory;
     @ManyToOne
     @JoinColumn
-    @Column(nullable = false)
     private FoodCategory foodCategory;
     @OneToOne
     @JoinColumn

--- a/TodaysLunch/src/main/java/LikeLion/TodaysLunch/domain/Member.java
+++ b/TodaysLunch/src/main/java/LikeLion/TodaysLunch/domain/Member.java
@@ -42,9 +42,11 @@ public class Member implements UserDetails {
 
     @ManyToOne
     @JoinColumn
+    @Column(nullable = false)
     private LocationCategory locationCategory;
     @ManyToOne
     @JoinColumn
+    @Column(nullable = false)
     private FoodCategory foodCategory;
     @OneToOne
     @JoinColumn
@@ -61,9 +63,6 @@ public class Member implements UserDetails {
         this.password = password;
     }
 
-//    @OneToMany(cascade = CascadeType.REMOVE, mappedBy = "member")
-//    private List<Review> review = new ArrayList<>();
-
 
     public Long getId() {
         return id;
@@ -74,16 +73,10 @@ public class Member implements UserDetails {
         return nickname;
     }
 
-    /*public List<Review> getReview() {
-        return review;
-    }*/
     public String getPassword() {
         return password;
     }
 
-//    public List<Review> getReview() {
-//        return review;
-//    }
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {

--- a/TodaysLunch/src/main/java/LikeLion/TodaysLunch/domain/Menu.java
+++ b/TodaysLunch/src/main/java/LikeLion/TodaysLunch/domain/Menu.java
@@ -1,6 +1,7 @@
 package LikeLion.TodaysLunch.domain;
 
 import com.sun.istack.NotNull;
+import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
@@ -18,11 +19,12 @@ public class Menu {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
-  @NotNull
+  @Column(nullable = false)
   private String name;
   private Long price;
   @ManyToOne
   @JoinColumn
+  @Column(nullable = false)
   private Restaurant restaurant;
   @OneToOne
   @JoinColumn

--- a/TodaysLunch/src/main/java/LikeLion/TodaysLunch/domain/Menu.java
+++ b/TodaysLunch/src/main/java/LikeLion/TodaysLunch/domain/Menu.java
@@ -24,13 +24,9 @@ public class Menu {
   private Long price;
   @ManyToOne
   @JoinColumn
-  @Column(nullable = false)
   private Restaurant restaurant;
   @OneToOne
   @JoinColumn
   private Sale sale;
-  @OneToOne
-  @JoinColumn
-  private ImageUrl imageUrl;
 
 }

--- a/TodaysLunch/src/main/java/LikeLion/TodaysLunch/domain/Restaurant.java
+++ b/TodaysLunch/src/main/java/LikeLion/TodaysLunch/domain/Restaurant.java
@@ -47,8 +47,10 @@ public class Restaurant {
   private LocalDate startDate;
   private LocalDate endDate;
   private Long agreement;
-
   private Long reviewCount;
+  @OneToOne
+  @JoinColumn
+  private Member member;
 
   // 맛집 심사를 위한 등록에서 쓰임
   @Builder

--- a/TodaysLunch/src/main/java/LikeLion/TodaysLunch/domain/Restaurant.java
+++ b/TodaysLunch/src/main/java/LikeLion/TodaysLunch/domain/Restaurant.java
@@ -27,15 +27,12 @@ public class Restaurant {
   private String restaurantName;
   @ManyToOne
   @JoinColumn
-  @Column(nullable = false)
   private FoodCategory foodCategory;
   @ManyToOne
   @JoinColumn
-  @Column(nullable = false)
   private LocationCategory locationCategory;
   @ManyToOne
   @JoinColumn
-  @Column(nullable = false)
   private LocationTag locationTag;
   @OneToOne
   @JoinColumn

--- a/TodaysLunch/src/main/java/LikeLion/TodaysLunch/domain/Restaurant.java
+++ b/TodaysLunch/src/main/java/LikeLion/TodaysLunch/domain/Restaurant.java
@@ -81,4 +81,5 @@ public class Restaurant {
   public void setReviewCount(Long reviewCount) {
     this.reviewCount = reviewCount;
   }
+  public void setMember(Member member) { this.member = member; }
 }

--- a/TodaysLunch/src/main/java/LikeLion/TodaysLunch/domain/Restaurant.java
+++ b/TodaysLunch/src/main/java/LikeLion/TodaysLunch/domain/Restaurant.java
@@ -23,16 +23,19 @@ public class Restaurant {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
-  @NotNull
+  @Column(nullable = false)
   private String restaurantName;
   @ManyToOne
   @JoinColumn
+  @Column(nullable = false)
   private FoodCategory foodCategory;
   @ManyToOne
   @JoinColumn
+  @Column(nullable = false)
   private LocationCategory locationCategory;
   @ManyToOne
   @JoinColumn
+  @Column(nullable = false)
   private LocationTag locationTag;
   @OneToOne
   @JoinColumn

--- a/TodaysLunch/src/main/java/LikeLion/TodaysLunch/domain/Restaurant.java
+++ b/TodaysLunch/src/main/java/LikeLion/TodaysLunch/domain/Restaurant.java
@@ -48,6 +48,7 @@ public class Restaurant {
   private LocalDate endDate;
   private Long agreement;
   private Long reviewCount;
+  private Long lowestPrice;
   @OneToOne
   @JoinColumn
   private Member member;
@@ -82,4 +83,5 @@ public class Restaurant {
     this.reviewCount = reviewCount;
   }
   public void setMember(Member member) { this.member = member; }
+  public void setLowestPrice(Long lowestPrice) { this.lowestPrice = lowestPrice; }
 }

--- a/TodaysLunch/src/main/java/LikeLion/TodaysLunch/domain/Review.java
+++ b/TodaysLunch/src/main/java/LikeLion/TodaysLunch/domain/Review.java
@@ -31,11 +31,13 @@ public class Review {
   private Long id;
   @Column(length = 200, nullable = false)
   private String reviewContent;
+  @Column(nullable = false)
   private Integer rating;
   private Long reviewRecmd;
   private Long reviewDecmd;
   @ManyToOne
   @JoinColumn
+  @Column(nullable = false)
   private Restaurant restaurant;
 
   @Builder

--- a/TodaysLunch/src/main/java/LikeLion/TodaysLunch/domain/Review.java
+++ b/TodaysLunch/src/main/java/LikeLion/TodaysLunch/domain/Review.java
@@ -37,7 +37,6 @@ public class Review {
   private Long reviewDecmd;
   @ManyToOne
   @JoinColumn
-  @Column(nullable = false)
   private Restaurant restaurant;
 
   @Builder

--- a/TodaysLunch/src/main/java/LikeLion/TodaysLunch/repository/ImageUrlRepository.java
+++ b/TodaysLunch/src/main/java/LikeLion/TodaysLunch/repository/ImageUrlRepository.java
@@ -1,8 +1,11 @@
 package LikeLion.TodaysLunch.repository;
 
 import LikeLion.TodaysLunch.domain.ImageUrl;
+import LikeLion.TodaysLunch.domain.Menu;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ImageUrlRepository extends JpaRepository<ImageUrl, Long> {
+  List<ImageUrl> findAllByMenu(Menu menu);
 
 }

--- a/TodaysLunch/src/main/java/LikeLion/TodaysLunch/repository/MenuRepository.java
+++ b/TodaysLunch/src/main/java/LikeLion/TodaysLunch/repository/MenuRepository.java
@@ -9,7 +9,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MenuRepository extends JpaRepository<Menu, Long> {
-  List<Menu> findAllByRestaurant(Restaurant restaurant);
+  Page<Menu> findAllByRestaurant(Restaurant restaurant, Pageable pageable);
   Page<Menu> findByNameContaining(String keyword, Pageable pageable);
   Page<Menu> findBySaleIsNotNull(Pageable pageable);
   Menu findBySale(Sale sale);

--- a/TodaysLunch/src/main/java/LikeLion/TodaysLunch/service/MenuService.java
+++ b/TodaysLunch/src/main/java/LikeLion/TodaysLunch/service/MenuService.java
@@ -46,6 +46,12 @@ public class MenuService {
 
   public Menu create(MultipartFile menuImage, String name, Long price, Long restaurantId) throws IOException {
     Restaurant restaurant = restaurantRepository.findById(restaurantId).get();
+    // 최저 메뉴 가격 설정
+    Long originalLowestPrice = restaurant.getLowestPrice();
+    if (originalLowestPrice == null || originalLowestPrice > price){
+      restaurant.setLowestPrice(price);
+      restaurantRepository.save(restaurant);
+    }
     Menu menu = new Menu();
     menu.setName(name);
     menu.setPrice(price);

--- a/TodaysLunch/src/main/java/LikeLion/TodaysLunch/service/MenuService.java
+++ b/TodaysLunch/src/main/java/LikeLion/TodaysLunch/service/MenuService.java
@@ -76,30 +76,18 @@ public class MenuService {
   }
 
   public Menu update(String name, Long price, Long restaurantId, Long menuId){
-    Menu menu = menuRepository.findById(menuId).get();
-//    if(menuImage != null && !menuImage.isEmpty()){
-//      // 기존 image를 s3에서 삭제
-//      ImageUrl deleteImage = new ImageUrl();
-//      if(menu.getImageUrl() != null) {
-//        deleteImage = menu.getImageUrl();
-//        s3UploadService.delete(deleteImage.getImageUrl()); // (전체 url string을 넘김)
-//      }
-//
-//      // s3에 update된 image 저장
-//      String savedUrl = s3UploadService.upload(menuImage, "menu");
-//
-//      // update된 image url을 db에 저장하고 menu에 등록
-//      ImageUrl imageUrl = new ImageUrl();
-//      String originalName = menuImage.getOriginalFilename();
-//      imageUrl.setOriginalName(originalName);
-//      imageUrl.setImageUrl(savedUrl);
-//      imageUrlRepository.save(imageUrl);
-//      menu.setImageUrl(imageUrl);
-//      // 기존 image url을 db에서 삭제
-//      if(deleteImage.getImageUrl() != null) {
-//        imageUrlRepository.delete(deleteImage);
-//      }
-//    }
+    Menu menu = menuRepository.findById(menuId)
+        .orElseThrow(() -> new IllegalArgumentException("메뉴 수정 실패! 메뉴를 수정하기 위한 대상 메뉴가 없습니다."));
+    Restaurant restaurant = restaurantRepository.findById(restaurantId)
+        .orElseThrow(() -> new IllegalArgumentException("메뉴 수정 실패! 메뉴를 수정하기 위한 대상 맛집이 없습니다."));
+
+    // 최저 메뉴 가격 설정
+    Long originalLowestPrice = restaurant.getLowestPrice();
+    if (originalLowestPrice == null || originalLowestPrice > price){
+      restaurant.setLowestPrice(price);
+      restaurantRepository.save(restaurant);
+    }
+
     if(name != null) menu.setName(name);
     if(price != null) menu.setPrice(price);
 

--- a/TodaysLunch/src/main/java/LikeLion/TodaysLunch/service/MenuService.java
+++ b/TodaysLunch/src/main/java/LikeLion/TodaysLunch/service/MenuService.java
@@ -35,8 +35,8 @@ public class MenuService {
     this.restaurantRepository = restaurantRepository;
   }
 
-  public List<Menu> findMenuByRestaurant(Restaurant restaurant){
-    return menuRepository.findAllByRestaurant(restaurant);
+  public Page<Menu> findMenuByRestaurant(Restaurant restaurant, Pageable pageable){
+    return menuRepository.findAllByRestaurant(restaurant, pageable);
   }
 
   public Page<Menu> searchMenuName(String keyword, Pageable pageable){

--- a/TodaysLunch/src/main/java/LikeLion/TodaysLunch/service/RestaurantService.java
+++ b/TodaysLunch/src/main/java/LikeLion/TodaysLunch/service/RestaurantService.java
@@ -4,6 +4,7 @@ import LikeLion.TodaysLunch.domain.FoodCategory;
 import LikeLion.TodaysLunch.domain.ImageUrl;
 import LikeLion.TodaysLunch.domain.LocationCategory;
 import LikeLion.TodaysLunch.domain.LocationTag;
+import LikeLion.TodaysLunch.domain.Member;
 import LikeLion.TodaysLunch.domain.Restaurant;
 import LikeLion.TodaysLunch.dto.JudgeDto;
 import LikeLion.TodaysLunch.repository.DataJpaRestaurantRepository;
@@ -84,16 +85,20 @@ public class RestaurantService {
     return restaurantRepository.findById(id).get();
   }
 
-  public Restaurant createJudgeRestaurant(String address, String restaurantName, String foodCategoryName,
+  public Restaurant createJudgeRestaurant(Member member, String address, String restaurantName, String foodCategoryName,
       String locationCategoryName, String locationTagName, String introduction,  MultipartFile restaurantImage)
       throws IOException {
-    FoodCategory foodCategory = foodCategoryRepository.findByName(foodCategoryName).get();
-    LocationCategory locationCategory = locationCategoryRepository.findByName(locationCategoryName).get();
-    LocationTag locationTag = locationTagRepository.findByName(locationTagName).get();
+    FoodCategory foodCategory = foodCategoryRepository.findByName(foodCategoryName)
+        .orElseThrow(() -> new IllegalArgumentException("음식 카테고리 "+foodCategoryName+" 찾기 실패! 심사 맛집을 등록할 수 없습니다."));
+    LocationCategory locationCategory = locationCategoryRepository.findByName(locationCategoryName)
+        .orElseThrow(() -> new IllegalArgumentException("위치 카테고리 "+locationCategoryName+" 찾기 실패! 심사 맛집을 등록할 수 없습니다."));
+    LocationTag locationTag = locationTagRepository.findByName(locationTagName)
+        .orElseThrow(() -> new IllegalArgumentException("위치 태그 "+locationTagName+" 찾기 실패! 심사 맛집을 등록할 수 없습니다."));
 
     JudgeDto judgeDto = new JudgeDto(restaurantName, foodCategory,
         locationCategory, locationTag, address, introduction);
     Restaurant restaurant = judgeDto.toEntity();
+    restaurant.setMember(member);
 
     if(!restaurantImage.isEmpty()) {
       ImageUrl imageUrl = new ImageUrl();

--- a/TodaysLunch/src/main/java/LikeLion/TodaysLunch/service/RestaurantService.java
+++ b/TodaysLunch/src/main/java/LikeLion/TodaysLunch/service/RestaurantService.java
@@ -55,9 +55,9 @@ public class RestaurantService {
 
     Pageable pageable = determineSort(page, size, sort, order);
 
-    FoodCategory foodCategoryObj = new FoodCategory();
-    LocationCategory locationCategoryObj = new LocationCategory();
-    LocationTag locationTagObj = new LocationTag();
+    FoodCategory foodCategoryObj;
+    LocationCategory locationCategoryObj;
+    LocationTag locationTagObj;
 
     Specification<Restaurant> spec =(root, query, criteriaBuilder) -> null;
     if (foodCategory != null) {
@@ -85,7 +85,7 @@ public class RestaurantService {
     return restaurantRepository.findById(id).get();
   }
 
-  public Restaurant createJudgeRestaurant(Member member, String address, String restaurantName, String foodCategoryName,
+  public Restaurant createJudgeRestaurant(String address, String restaurantName, String foodCategoryName,
       String locationCategoryName, String locationTagName, String introduction,  MultipartFile restaurantImage)
       throws IOException {
     FoodCategory foodCategory = foodCategoryRepository.findByName(foodCategoryName)
@@ -98,7 +98,6 @@ public class RestaurantService {
     JudgeDto judgeDto = new JudgeDto(restaurantName, foodCategory,
         locationCategory, locationTag, address, introduction);
     Restaurant restaurant = judgeDto.toEntity();
-    restaurant.setMember(member);
 
     if(!restaurantImage.isEmpty()) {
       ImageUrl imageUrl = new ImageUrl();


### PR DESCRIPTION
1. 유저의 Food Category와 Location Category에 따라 맛집을 추천해주는 '맛집 추천' API 구현
2. Restaurant 도메인에 최소 메뉴 가격 필드를 추가
3. Menu Service의 create, update 메서드에서 최소 가격 메뉴인지 점검하는 로직 추가
4. 한 메뉴 당 여러 이미지를 등록할 수 있도록 ImageUrl 도메인과 Menu 도메인의 join 관계 수정하고 이에 따라 Menu Service의 로직 수정
5. 페이징을 요구하는 GET API에서, 전체 페이지 수를 응답 데이터에 함께 넣어 Client server에 보내도록 수정